### PR TITLE
Use default jar packaging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,6 @@
 	<groupId>com.thedevfamily</groupId>
 	<artifactId>usermanagement</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
-	<packaging>war</packaging>
 	<name>usermanagement</name>
 	<description>User Management</description>
 


### PR DESCRIPTION
Nothing in the blog post or this project requires a `war` file so I suggest to switch to the default packaging.